### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/Blink/keywords.txt
+++ b/Blink/keywords.txt
@@ -1,6 +1,6 @@
-Blink   KEYWORD1
-startBlink  KEYWORD2
-getOnInterval   KEYWORD2
-getOffInterval  KEYWORD2
-setOnInterval   KEYWORD2
-setOffInterval  KEYWORD2
+Blink	KEYWORD1
+startBlink	KEYWORD2
+getOnInterval	KEYWORD2
+getOffInterval	KEYWORD2
+setOnInterval	KEYWORD2
+setOffInterval	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords